### PR TITLE
Updating installer to use jetstream

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-VAMP_INSTALLER_VERSION=2.0.15
+VAMP_INSTALLER_VERSION=3.0.7
 VAMP_INSTALLER_IMAGE=${DEFAULT_VAMP_INSTALLER_IMAGE:=vampio/k8s-installer:$VAMP_INSTALLER_VERSION}
 VAMP_INSTALLER_BOOTSTRAP_YAML=${DEFAULT_VAMP_BOOTSTRAP_YAML:=https://raw.githubusercontent.com/magneticio/vamp-cloud-installer/master/bootstrap-policy.yaml}
 


### PR DESCRIPTION
This PR enables jetstream for production. It should only be merged during the final stages of the pentest migration